### PR TITLE
feat: renombrar Insignias por Formación y añadir enlace Trayectoria al menú

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -75,9 +75,15 @@ style = "github-dark"
   target = "_blank"
 
 [[menu.main]]
-  name = "Insignias"
+  name = "Formación"
   weight = 2
   url = "/badges/"
+
+[[menu.main]]
+  name = "Trayectoria"
+  weight = 3
+  url = "https://www.linkedin.com/in/colomr-cv/"
+  target = "_blank"
 
 
 


### PR DESCRIPTION
- Renombra el item de menú "Insignias" a "Formación"
- Añade nuevo item "Trayectoria" con enlace externo al perfil de LinkedIn

https://claude.ai/code/session_01T3GX77m9Z9ZuFhXG1RXuNJ