### PR TITLE
fix: actualizar título del sitio

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,5 +1,5 @@
 baseurl = "https://colomr.pm/"
-title = "GCP Presales Manager | Google Cloud Expert"
+title = "Google Cloud Presales Engineer"
 theme = "colomr-v1"
 languagecode = "es"
 defaultcontentlanguage = "es"


### PR DESCRIPTION
## Summary
- Cambiar título del sitio: "GCP Presales Manager | Google Cloud Expert" → "Google Cloud Presales Engineer"

## Test plan
- [ ] Verificar `<title>` en todas las páginas

🤖 Generated with [Claude Code](https://claude.com/claude-code)