### PR TITLE
fix: renombrar Frontier AI Practitioner a AI Practitioner

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Home"
+title: "AI Practitioner | Google Cloud · Anthropic"
 
 # Hero section
 hero:

--- a/content/quien/index.md
+++ b/content/quien/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Sobre mí"
-description: "Francisco Colomer — Frontier AI Practitioner"
+description: "Francisco Colomer — AI Practitioner"
 url: "/sobre-mi/"
 layout: "blocks"
 
@@ -14,11 +14,11 @@ cover_ratio: "16 / 9"
 cover_opacity: "0.50"
 icon: "👨‍💻"
 pageTitle: "Francisco Colomer"
-subtitle: "Frontier AI Practitioner"
+subtitle: "AI Practitioner"
 
 tags_list:
   - label: "Google Cloud"
-  - label: "Frontier AI Practitioner"
+  - label: "AI Practitioner"
   - label: "Vibe Coder"
 
 # Content blocks (Notion-style)

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,5 +1,5 @@
 baseurl = "https://colomr.pm/"
-title = "Frontier AI Practitioner"
+title = "AI Practitioner"
 theme = "colomr-v1"
 languagecode = "es"
 defaultcontentlanguage = "es"


### PR DESCRIPTION
## Summary
- Renombra "Frontier AI Practitioner" a "AI Practitioner" en título del sitio, descripción, subtítulo y tags de la página sobre-mí

## Test plan
- [ ] Verificar que el título del sitio muestra "AI Practitioner"
- [ ] Verificar que la página /sobre-mi/ muestra el subtítulo y tag actualizados

🤖 Generated with [Claude Code](https://claude.com/claude-code)