### PR TITLE
chore: migrar TLD de colomr.pm a colomr.cc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — Contexto del proyecto colomr.pm
+# CLAUDE.md — Contexto del proyecto colomr.cc
 
 ## Qué es este proyecto
 Sitio web personal generado con **Hugo** y desplegado en **Firebase Hosting**.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# colomr.pm
+# colomr.cc
 
 Sitio web personal construido con [Hugo](https://gohugo.io/) y desplegado en [Firebase Hosting](https://firebase.google.com/).
 
@@ -15,7 +15,7 @@ Tema propio [colomr-v1](https://github.com/colomr-dev/colomr-v1-theme) basado en
 ## Estructura
 
 ```
-colomr.pm/
+colomr.cc/
 ├── hugo.toml                    # Configuración del sitio
 ├── content/
 │   ├── _index.md                # Home
@@ -43,7 +43,7 @@ colomr.pm/
 
 ```bash
 # Clonar con submódulos
-git clone --recurse-submodules https://github.com/colomr-dev/colomr.pm.git
+git clone --recurse-submodules https://github.com/colomr-dev/colomr.cc.git
 
 # Servidor local
 hugo server
@@ -78,4 +78,4 @@ El tema colomr-v1 está bajo [GPL-3.0](https://github.com/colomr-dev/colomr-v1-t
 
 ## Autor
 
-**Francisco Colomer** — [colomr.pm](https://colomr.pm)
+**Francisco Colomer** — [colomr.cc](https://colomr.cc)

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -1,4 +1,4 @@
-// Custom styles for colomr.pm
+// Custom styles for colomr.cc
 
 // Define variables needed for badges (from theme)
 $bg-color: #fafafa !default;

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseurl = "https://colomr.pm/"
+baseurl = "https://colomr.cc/"
 title = "AI Practitioner"
 theme = "colomr-v1"
 languagecode = "es"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "colomr.pm",
+  "name": "colomr.cc",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/static/site.webmanifest
+++ b/static/site.webmanifest
@@ -1,6 +1,6 @@
 {
   "name": "GCP Presales Manager | Google Cloud Expert",
-  "short_name": "colomr.pm",
+  "short_name": "colomr.cc",
   "description": "Preventa técnica de Google Cloud Platform (GCP)",
   "start_url": "/",
   "display": "browser",


### PR DESCRIPTION
## Summary
- Actualiza `baseurl` en `hugo.toml` de `colomr.pm` a `colomr.cc`
- Actualiza `site.webmanifest`, `package-lock.json`, `README.md`, `CLAUDE.md` y `custom.scss`
- Actualiza `theme.toml` y `README.md` del submódulo `colomr-v1` (homepage URLs)

## Prerequisitos antes de mergear
- [ ] Dominio `colomr.cc` añadido en Firebase Hosting (proyecto `pvtech-site`)
- [ ] DNS de `colomr.cc` apuntando a Firebase y SSL provisionado
- [ ] Verificar que `https://colomr.cc` sirve contenido

## Post-merge
- [ ] Configurar redirección 301 de `colomr.pm` → `colomr.cc` (registrador DNS)
- [ ] Actualizar Google Analytics (stream URL)
- [ ] Registrar `colomr.cc` en Google Search Console + cambio de dirección
- [ ] Renombrar repo en GitHub de `colomr.pm` a `colomr.cc` (último paso)

🤖 Generated with [Claude Code](https://claude.com/claude-code)