### PR TITLE
feat: actualizar contenido (título, LinkedIn, GitHub, párrafo)

### DIFF
--- a/.github/workflows/sync-theme.yml
+++ b/.github/workflows/sync-theme.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Push submodule to public repo
         run: |
           cd themes/colomr-v1
-          git remote set-url origin https://x-access-token:${{ secrets.THEME_SYNC_PAT }}@github.com/colomr-dev/colomr-v1-theme.git
+          git remote set-url origin https://x-access-token:${{ secrets.THEME_SYNC_PAT }}@github.com/colomr-cc/colomr-v1-theme.git
           git push origin HEAD:main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/colomr-v1"]
 	path = themes/colomr-v1
-	url = https://github.com/colomr-dev/colomr-v1-theme.git
+	url = https://github.com/colomr-cc/colomr-v1-theme.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Rama principal: **`main`**. Tema colomr-v1 en producción.
 - `scripts/MANUAL_BADGES.md` — procedimiento manual para badges Anthropic
 - `.github/workflows/sync-badges.yml` — sync semanal (lunes 8:00 UTC)
 - `.github/workflows/sync-theme.yml` — sincroniza tema al repo público (pendiente PAT)
-- `themes/colomr-v1/` — submódulo git → https://github.com/colomr-dev/colomr-v1-theme
+- `themes/colomr-v1/` — submódulo git → https://github.com/colomr-cc/colomr-v1-theme
 - `layouts/` — overrides personales (footer, iconos gemini/claude)
 - `content/*/index.md` — Page Bundles, contenido en front matter YAML
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Sitio web personal construido con [Hugo](https://gohugo.io/) y desplegado en [Firebase Hosting](https://firebase.google.com/).
 
-Tema propio [colomr-v1](https://github.com/colomr-dev/colomr-v1-theme) basado en Material Design 3.
+Tema propio [colomr-v1](https://github.com/colomr-cc/colomr-v1-theme) basado en Material Design 3.
 
 ## Tecnologias
 
@@ -43,7 +43,7 @@ colomr.cc/
 
 ```bash
 # Clonar con submódulos
-git clone --recurse-submodules https://github.com/colomr-dev/colomr.cc.git
+git clone --recurse-submodules https://github.com/colomr-cc/colomr.cc.git
 
 # Servidor local
 hugo server
@@ -74,7 +74,7 @@ Procedimiento documentado en [scripts/MANUAL_BADGES.md](scripts/MANUAL_BADGES.md
 
 El código de este sitio está bajo [MIT License](LICENSE).
 El contenido (textos, imágenes, datos personales) es propiedad del autor.
-El tema colomr-v1 está bajo [GPL-3.0](https://github.com/colomr-dev/colomr-v1-theme/blob/main/LICENSE).
+El tema colomr-v1 está bajo [GPL-3.0](https://github.com/colomr-cc/colomr-v1-theme/blob/main/LICENSE).
 
 ## Autor
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "AI Practitioner | Google Cloud · Anthropic"
+title: "AI Practitioner | Claude Code"
 
 # Hero section
 hero:

--- a/content/donde/index.md
+++ b/content/donde/index.md
@@ -44,6 +44,6 @@ blocks:
     body: "Mis siguientes retos deben estar alineados con oportunidades para crecer en el campo de la Inteligencia Artificial, especialmente con soluciones de Google y/o Anthropic."
     items:
       - label: "LinkedIn"
-        url: "https://www.linkedin.com/in/colomr-cv/"
+        url: "https://www.linkedin.com/in/colomr"
         icon: "fa fa-linkedin"
 ---

--- a/content/quien/index.md
+++ b/content/quien/index.md
@@ -32,7 +32,7 @@ blocks:
 
       No negocié precio, negocié que mi equipo tuviera un nuevo hogar. Me quedé dos años dentro, viendo cómo se integra una adquisición. Ahora sé leer cuándo una tecnología empuja al negocio y cuándo el negocio va arrastrando a la tecnología.
 
-      Busco mi próximo reto como Forward-Deployed / Customer / Solutions Engineer en una compañía que cree su propio producto de IA. Prefiero la operativa de campo a la teoría de despacho.
+      Busco mi próximo reto como Presales / Customer / Solutions Engineer en una compañía que cree su propio producto de IA.
 
   - type: "cards"
     heading: "En qué destaco"
@@ -79,10 +79,10 @@ blocks:
     heading: "Encuéntrame en"
     items:
       - label: "LinkedIn"
-        url: "https://www.linkedin.com/in/colomr-cv/"
+        url: "https://www.linkedin.com/in/colomr"
         icon: "fa fa-linkedin"
       - label: "GitHub"
-        url: "https://github.com/colomr-dev"
+        url: "https://github.com/colomr-cc"
         icon: "fa fa-github"
       - label: "Google for Developers"
         url: "https://g.dev/colomr"

--- a/hugo.toml
+++ b/hugo.toml
@@ -25,12 +25,12 @@ googleAnalytics = 'G-Y0X8CR726Y'
   name = "Github"
   icon = "fa fa-github fa-2x"
   weight = 1
-  url = "https://github.com/colomr-dev"
+  url = "https://github.com/colomr-cc"
 [[params.social]]
   name = "LinkedIn"
   icon = "fa fa-linkedin fa-2x"
   weight = 2
-  url = "https://www.linkedin.com/in/colomr-cv/"
+  url = "https://www.linkedin.com/in/colomr"
 [[params.social]]
   name = "Google Cloud"
   icon = "fa fa-google fa-2x"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,7 +8,7 @@
       {{ end }}
     </div>
     <p class="footer-credit">
-      © {{ .Site.Params.since }} - {{ now.Year }} {{ .Site.Params.author }} · Desarrollado con 💚 usando <a href="https://gohugo.io/" target="_blank" rel="noopener">Hugo</a>, <a href="https://github.com/colomr-dev/colomr-v1-theme" target="_blank" rel="noopener">colomr-v1</a> y <a href="https://claude.ai" target="_blank" rel="noopener">Claude</a>.
+      © {{ .Site.Params.since }} - {{ now.Year }} {{ .Site.Params.author }} · Desarrollado con 💚 usando <a href="https://gohugo.io/" target="_blank" rel="noopener">Hugo</a>, <a href="https://github.com/colomr-cc/colomr-v1-theme" target="_blank" rel="noopener">colomr-v1</a> y <a href="https://claude.ai" target="_blank" rel="noopener">Claude</a>.
     </p>
   </div>
 </footer>


### PR DESCRIPTION
## Summary
- Título del home: "AI Practitioner | Google Cloud · Anthropic" → "AI Practitioner | Claude Code"
- URLs de LinkedIn: `colomr-cv` → `colomr` (3 sitios)
- Usuario GitHub: `colomr-dev` → `colomr-cc` (8 sitios: config, footer, submódulo, workflow, README, CLAUDE.md)
- Párrafo profesional en "Sobre mí": rol actualizado a Presales y eliminada frase final

## Test plan
- [x] Verificar título del tab en home
- [x] Verificar links de LinkedIn en footer, "Sobre mí" y "Visión"
- [x] Verificar links de GitHub en footer, "Sobre mí" y config
- [x] Verificar párrafo actualizado en /sobre-mi/
- [x] Confirmar que el deploy automático funciona correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)