### PR TITLE
sanity-check: fallar si el scraping devuelve 0 badges

### DIFF
--- a/scripts/sync_badges.py
+++ b/scripts/sync_badges.py
@@ -57,6 +57,12 @@ def fetch_profile_badges() -> list[dict]:
             "url": url,
         })
 
+    if len(badges) == 0:
+        raise RuntimeError(
+            f"Scraping devolvió 0 badges desde {PROFILE_URL}. "
+            "Probablemente Google cambió el HTML del perfil — revisar selectores CSS."
+        )
+
     return badges
 
 


### PR DESCRIPTION
El scraping de badges buscaba clases CSS concretas del perfil de Google y, si Google cambiaba el HTML, devolvía una lista vacía sin lanzar error. Eso dejaba el job en verde y la página desactualizada en silencio. Ahora el script lanza `RuntimeError` si scrapea 0 badges, convirtiendo ese fallo silencioso en un job rojo que dispara el email de aviso de GitHub Actions.