### PR TITLE
corrige fecha del badge Claude 101

### DIFF
--- a/data/anthropic_badges.json
+++ b/data/anthropic_badges.json
@@ -10,7 +10,7 @@
   {
     "titulo": "Claude 101",
     "img": "/images/anthropic-claude101-opt.jpg",
-    "fecha": "2024-12-01",
+    "fecha": "2026-03-01",
     "url": "https://verify.skilljar.com/c/46ocuxdgxcvz",
     "desc": "Fundamentos del uso de Claude: prompting, contexto, seguridad y buenas prácticas para integrar IA en flujos de trabajo reales.",
     "desc_en": "Claude fundamentals: prompting, context, safety and best practices for integrating AI into real-world workflows.",


### PR DESCRIPTION
La fecha de `Claude 101` estaba mal (dic 2024); la real es marzo de 2026. Se muestra solo mes+año, así que el día no es visible.