### PR TITLE
actualizado tagline y reformulado texto de sobre-mí (es/en)

### DIFF
--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -1,5 +1,5 @@
 ---
-title: "AI Practitioner | Claude Code"
+title: "AI Practitioner | Cloud Architect | Solo Developer"
 
 # Hero section
 hero:

--- a/content/_index.es.md
+++ b/content/_index.es.md
@@ -1,5 +1,5 @@
 ---
-title: "AI Practitioner | Claude Code"
+title: "AI Practitioner | Cloud Architect | Solo Developer"
 
 # Hero section
 hero:

--- a/content/quien/index.en.md
+++ b/content/quien/index.en.md
@@ -11,7 +11,7 @@ cover_ratio: "16 / 9"
 cover_opacity: "0.50"
 icon: "👾"
 pageTitle: "Francisco Colomer"
-subtitle: "AI Practitioner"
+subtitle: "AI Practitioner | Cloud Architect | Solo Developer"
 
 tags_list:
   - label: "Google Cloud"
@@ -23,13 +23,14 @@ blocks:
   - type: "text"
     heading: "About me"
     body: |
-      When the AI ​​wave arrived, I didn't wait: I've delivered over 100 courses, 130 labs, and 550 lessons on Google Cloud Skills Boost between 2023 and 2026, all on my own initiative. Google recognized me as a leading Presales Engineer within its Partner ecosystem.
+      I started as a kid with an Amstrad CPC464. I watched the PC, the Internet, Virtualization, the Cloud, and now Artificial Intelligence come to life. Every new revolution builds on what I already learned — I feel privileged to live through such an exciting era firsthand.
 
-      Before that, I worked at IBM Greenock, Sun Microsystems Edinburgh and RIM London. I co-founded a company as a technical architect with equity. I founded another company wholly-owned and operated it for nine years with my own team, until a larger company saw what we were building and proposed a merger.
+      In my junior years, enthusiasm took me to IBM Greenock, Sun Microsystems Edinburgh, and RIM London. I returned to Spain and co-founded an e-commerce company as technical director. Two years later I launched a wholly-owned company and ran it for nine years, until a larger firm proposed integrating us. I left the SMB market, tired of stitching together multi-vendor solutions. I decided to focus on Google as a single vendor; I've spent the last five years at a startup acquired by Telefónica, helping enterprises migrate their workloads to Google Cloud. My role as a GCP Presales Engineer lets me sit at the intersection of business and technology — right where I feel at home.
 
-      I stayed on for two years, observing how an acquisition is integrated. Now I know when the  technology is driving the business and when the business is driving the technology.
+      - By day, I design Google Cloud architectures for large accounts: RFPs, technical demos, complex sales cycles... Here I learn how a big organization thinks when it's afraid of getting it wrong.
+      - In my spare time I design and build "things" that now run on their own 🤖. Owning my side-projects end-to-end gives me a 360° perspective no course can teach: idea, prototyping, architecture, code, quality, deployment, maintenance, and so on.
 
-      I'm looking for my next challenge as an FDE or Presales/Customer/Solutions Engineer at a company that develops its own AI product.
+      What motivates me is seeing growth and purpose in what I do. What burns me out is repeating without learning — the "we've always done it this way".
 
   - type: "cards"
     heading: "What I'm good at"

--- a/content/quien/index.es.md
+++ b/content/quien/index.es.md
@@ -14,7 +14,7 @@ cover_ratio: "16 / 9"
 cover_opacity: "0.50"
 icon: "👾"
 pageTitle: "Francisco Colomer"
-subtitle: "AI Practitioner"
+subtitle: "AI Practitioner | Cloud Architect | Solo Developer"
 
 tags_list:
   - label: "Google Cloud"
@@ -26,13 +26,14 @@ blocks:
   - type: "text"
     heading: "Sobre mí"
     body: |
-      Cuando llegó la ola de la IA, no esperé: Llevo más de 100 cursos, 130 labs, 550 lecciones en Google Cloud Skills Boost, entre 2023 y 2026, por iniciativa propia.  Google me reconoció como Presales Engineer referente dentro de su ecosistema de Partners.
+      Empecé de niño con un Amstrad CPC464. Vi nacer el PC, Internet, la Virtualización, la Nube, y ahora la Inteligencia Artificial. Cada nueva revolución se asienta sobre la base de lo que ya aprendí, me siento un privilegiado por vivir en primera persona esta época tan apasionante.
 
-      Antes de eso, trabajé en IBM Greenock, Sun Microsystems Edinburgh y RIM London. Co-fundé una empresa como arquitecto técnico con equity. Fundé otra al 100% y la operé nueve años con equipo propio, hasta que una empresa mayor vio lo que estábamos construyendo y propuso integrarnos.
+      En mi etapa de junior la ilusión me llevó a IBM Greenock, Sun Microsystems Edinburgh, RIM London. Regresé a España y co-fundé una empresa de E-Commerce como director técnico. Dos años más tarde lancé una compañía con capital propio y la operé nueve años, hasta que una empresa, de mayor tamaño, propuso integrarnos. Dejé el mercado de la PyME, cansado de tener que integrar soluciones multi-vendor. Decidí focalizarme en Google como único fabricante; llevo cinco años en una startup adquirida por Telefónica ayudando a empresas en su migración de cargas a Google Cloud. Mi trabajo de GCP Presales Engineer me facilita estar a caballo entre el negocio y la tecnología, rol donde me siento como pez en el agua.
 
-      Me quedé dos años dentro, viendo cómo se integra una adquisición. Ahora sé leer cuándo la  tecnología empuja al negocio y cuándo el negocio va arrastrando a la tecnología.
+      - De día diseño arquitecturas Google Cloud para grandes cuentas: RFPs, demos técnicas, ciclos de venta complejos... Aquí aprendo cómo piensa una organización grande cuando tiene miedo de equivocarse.
+      - En mi tiempo libre diseño y construyo "cosas" que ahora van solas 🤖. Encargarme de mis side-projects me da una visión 360º que ningún curso te enseña: idea, prototipado, arquitectura, código, calidad, despliegue, mantenimiento, etc.
 
-      Busco mi próximo reto como FDE o Presales/Customer/Solutions Engineer en una compañía que cree su propio producto de IA.
+      Lo que me motiva es ver crecimiento y sentido en lo que hago. Lo que me apaga es repetir sin aprender, el "siempre se ha hecho así".
 
   - type: "cards"
     heading: "En qué destaco"

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,5 +1,5 @@
 baseurl = "https://colomr.cc/"
-title = "AI Practitioner"
+title = "AI Practitioner | Cloud Architect | Solo Developer"
 theme = "colomr-v1"
 defaultContentLanguage = "es"
 defaultContentLanguageInSubdir = true


### PR DESCRIPTION
Nuevo tagline en todos los títulos (Home y páginas interiores): **AI Practitioner | Cloud Architect | Solo Developer**. Subtítulo de Sobre mí actualizado al mismo tagline, y texto del bloque reformulado en ES y EN.